### PR TITLE
Fix/gcc13 mem cpy strm error

### DIFF
--- a/opatIO-cpp/src/private/opatIO.cpp
+++ b/opatIO-cpp/src/private/opatIO.cpp
@@ -26,11 +26,10 @@
 #include <ostream>
 #include <stdexcept>
 #include <algorithm>
-#include <sys/types.h>
 #include <unordered_map>
-#include <cmath>
 #include <cstdint>
 #include <memory>
+#include <cstring>
 #include "picosha2.h"
 
 namespace opat {
@@ -222,7 +221,7 @@ namespace opat {
         file.read(reinterpret_cast<char*>(columnValues.get()), tableEntry.numColumns * sizeof(double));
         file.read(reinterpret_cast<char*>(data.get()), tableEntry.numRows * tableEntry.numColumns * tableEntry.size *sizeof(double));
 
-        if (file.gcount() != tableEntry.numRows * tableEntry.numColumns * tableEntry.size * sizeof(double)) {
+        if (static_cast<uint64_t>(file.gcount()) != tableEntry.numRows * tableEntry.numColumns * tableEntry.size * sizeof(double)) {
             throw std::runtime_error("Error reading OPAT table from file");
         }
 

--- a/opatIO-cpp/src/public/opatIO.h
+++ b/opatIO-cpp/src/public/opatIO.h
@@ -394,6 +394,8 @@ struct OPATTable {
      * @brief Prints the table to the standard output.
      */
     void print() const;
+
+    friend std::ostream& operator<<(std::ostream& os, const OPATTable& table);
 };
 
 /**

--- a/opatIO-fortran/src/opatio.f90
+++ b/opatIO-fortran/src/opatio.f90
@@ -212,7 +212,8 @@ CONTAINS ! --- Module Procedures ---
 
         IF (.not. found_null) THEN
              length = buffer_size
-             PRINT *, "Warning(C_F_STRCPY): Null terminator not found within buffer limit (", buffer_size, "). String might be truncated."
+             PRINT *, "Warning(C_F_STRCPY): Null terminator not found within buffer limit (", buffer_size, "). &
+  &           String might be truncated."
         END IF
 
         IF (length > 0) THEN

--- a/opatIO-py/src/opatio/convert/__init__.py
+++ b/opatIO-py/src/opatio/convert/__init__.py
@@ -15,5 +15,14 @@ Examples
 >>> from opatio.convert import OPALI_2_OPAT
 >>> # Convert an OPAL Type I file to OPAT format
 >>> OPALI_2_OPAT("GS98hz", "GS98hz.opat")
+
+>>> # Load the converted OPAT file
+>>> from opatio import read_opat
+>>> opat = read_opat("GS98hz.opat")
+
+Or you can use the `load_opat1_as_opat` function to load OPAL Type I directly
+>>> from opatio.convert import load_opat1_as_opat
+>>> opat = load_opat1_as_opat("GS98hz")
 """
 from .opal import OPALI_2_OPAT
+from .opal import load_opat1_as_opat


### PR DESCRIPTION
# 🐞 resolution to opat-core gcc compile errors

## 🚨 What’s the issue?
opat-core did not compile with gcc compilers due to their enhanced strictness regarding include directives, class friends, and fortran line length when compared to clang. This resulted in the OPATTable stream insertion operator being ill defined when compiling under gcc, the memcpy function being missing, and line 224 in opatio.f90 being too long. 

---

## 🛠️ What’s the fix?

- the stream insertion operator has been made a friend of OPATTable
- cstring has been included in opatIO.cpp, providing memcpy
- line 224 in opatio.f90 has been wrapped using standard fortran line wrap semantics. 


---

## 🧪 How was this tested?
The build system was run for both clang-16.0 and gcc-13.3.0 with the same source.

- [x] Manually Verified
- [ ] Unit Tests
- [ ] Other (please explain...)

---

## 🔗 Related bugs / reports

#15  This PR should resolve this issue

---

## 🧼 Any follow-up cleanup or other notes?
When compiling with gcc-13.3.0 a note is emited due to a change to the ABI with gcc 10.1 and how std::pair is passed around. This note can safely be ignored.

