### PR TITLE
docs(opatIO-cpp-tools): added more informative error messages for com…

### DIFF
--- a/opatIO-cpp/tools/opatHeader.cpp
+++ b/opatIO-cpp/tools/opatHeader.cpp
@@ -65,6 +65,6 @@ int main(int argc, char* argv[]) {
         }
     } else {
         // Display a message if no file path was provided.
-        std::cout << "No file path provided..." << std::endl;
+        std::cout << "No file path provided (Note that you must provide file paths as a flag, i.e. opatHeader -f <path/to/file>)..." << std::endl;
     }
 }

--- a/opatIO-cpp/tools/opatInspect.cpp
+++ b/opatIO-cpp/tools/opatInspect.cpp
@@ -75,6 +75,6 @@ int main(int argc, char* argv[]) {
         }
     } else {
         // No file path provided
-        std::cout << "No file path provided..." << std::endl;
+        std::cout << "No file path provided (Note that you must provide file paths as a flag, i.e. opatInspect -f <path/to/file>)..." << std::endl;
     }
 }

--- a/opatIO-cpp/tools/opatVerify.cpp
+++ b/opatIO-cpp/tools/opatVerify.cpp
@@ -65,6 +65,6 @@ int main(int argc, char* argv[]) {
         }
     } else {
         // No file path was provided in the command-line arguments
-        std::cout << "No file path provided..." << std::endl;
+        std::cout << "No file path provided (Note that you must provide file paths as a flag, i.e. opatVerify -f <path/to/file>)..." << std::endl;
     }
 }


### PR DESCRIPTION
# ✨ Feature Pull Request Template

## 🧠 What does this do?
Added more informative error message for `opatHeader`, `opatVerify`, and `opatInspect`

---

## 🎯 Why is this needed?
The command line usage of these tools requires paths be passed as a flag argument and not a positional argument (`-f <path/to/file>`). The error message t hat prints out if `-f` is not provided now states this requirement. 

---

## 🔧 How is it implemented?
Small change to the error message string in each utility


---

## ✅ How was it tested?
_Explain how you tested it and what cases you verified._

- [ ] Unit tests
- [x] Manual testing
- [ ] Other (please explain...)

---

## 📎 Related issues / tickets
#17 