### PR TITLE
 build(build): changed qhull and libopatio to shared libraries

### DIFF
--- a/build-config/qhull/meson.build
+++ b/build-config/qhull/meson.build
@@ -4,6 +4,7 @@ qhull_cmake_options.add_cmake_defines({
     'BUILD_SHARED_LIBS': 'ON',
     'BUILD_APPLICATIONS': 'OFF',
     'CMAKE_CXX_STANDARD': '14',
+    'BUILD_STATIC_LIBS': 'OFF',
 })
 qhull_cmake_options.set_override_option('warning_level', '0')
 qhull_cmake_options.set_override_option('cpp_std', 'c++14')

--- a/opatIO-cpp/src/meson.build
+++ b/opatIO-cpp/src/meson.build
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 # Define the libopatIO library so it can be linked against by other parts of the build system
-libopatio = static_library('opatio',
+libopatio = shared_library('opatio',
     opatio_sources, 
     include_directories: include_directories('public'),
     cpp_args: ['-fvisibility=default'],


### PR DESCRIPTION
# ✨ Feature Pull Request Template

## 🧠 What does this do?
This is a very minor PR which changes the built versions qhull and libopatio from static to shared libraries. This does not affect internal linking as that is all taken care of by meson. However, downstream, as we build python interfaces, we cannot link static libraries into python wheels. This change will make building python wheels much more streamlined. 

---

## 🎯 Why is this needed?
For building python bindings

---

## 🔧 How is it implemented?
changed libopatio to a shared library and added the  BUILD_STATIC_LIBS: ON option to the qhull CMake configuration


---

## ✅ How was it tested?

- [x] Unit tests
- [ ] Manual testing
- [ ] Other (please explain...)

---

## 📎 Related issues / tickets
