### PR TITLE
generate_pc option added to opat-core build process

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,13 +7,15 @@ subdir('opatIO-fortran')
 
 pkg = import('pkgconfig')
 
-pkg.generate(
-    name: 'opatIO',
-    description: 'C++ library for OPAT',
-    version: meson.project_version(),
-    libraries: [libopatio],
-    subdirs: ['opatIO'],
-    filebase: 'opatio',
-    install_dir: join_paths(get_option('libdir'), 'pkgconfig')
-)
-
+# There are cases where we do not want to generate the pkg-config file (such as when building opat-core as a part of a python library)
+if get_option('generate_pc')
+    pkg.generate(
+        name: 'opatIO',
+        description: 'C++ library for OPAT',
+        version: meson.project_version(),
+        libraries: [libopatio],
+        subdirs: ['opatIO'],
+        filebase: 'opatio',
+        install_dir: join_paths(get_option('libdir'), 'pkgconfig')
+    )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('generate_pc', type: 'boolean', value: true, description: 'Flag to control whether or not to generate a pkg-config file for the library. If set to false, no pkg-config file will be generated. This is useful for projects that do not require pkg-config support or when the library is not intended for public use.')


### PR DESCRIPTION
# ✨ Feature Pull Request Template

## 🧠 What does this do?
Adds a build option (default to true) to the opat-core build system `generate_pc` which controls whether or not opatIO.pc is generated by the build process. We may want to turn this off when building opat-core as part of `SERiF`.

---

## 🎯 Why is this needed?
Prevent conflicts putting unknown file types into python wheels 


---

## 🔧 How is it implemented?
meson_options.txt

---

## ✅ How was it tested?
_Explain how you tested it and what cases you verified._

- [ ] Unit tests
- [x] Manual testing
- [ ] Other (please explain...)

---

## 📎 Related issues / tickets
